### PR TITLE
Add map of module references for dependencies of linked modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,5 +90,15 @@
     "redux-devtools-extension": "^2.13.9",
     "redux-mock-store": "^1.5.4",
     "redux-saga-tester": "^1.0.874"
+  },
+  "jest": {
+    "moduleNameMapper": {
+      "^@cosmotech/core$": "<rootDir>/node_modules/@cosmotech/core",
+      "^@material-ui/core": "<rootDir>/node_modules/@material-ui/core",
+      "^@material-ui/icons": "<rootDir>/node_modules/@material-ui/icons",
+      "^@material-ui/styles": "<rootDir>/node_modules/@material-ui/styles",
+      "^react$": "<rootDir>/node_modules/react",
+      "^react-dom$": "<rootDir>/node_modules/react-dom"
+    }
   }
 }


### PR DESCRIPTION
Jest tests fail locally when `yarn link` points to a lib with
peer dependencies. This map configuration adds redirection to
import these dependencies from <rootDir>/node_modules instead
of the linked modules folders.

https://github.com/facebook/jest/issues/2447#issuecomment-297766714