### PR TITLE
fix: Change Dashboards view to have translated tabs

### DIFF
--- a/src/configs/App.config.js
+++ b/src/configs/App.config.js
@@ -49,7 +49,10 @@ export const applicationInsightConfig = {
 
 export const SCENARIO_DASHBOARD_CONFIG = [
   {
-    title: 'Scenario dashboard',
+    title: {
+      en: 'Scenario dashboard',
+      fr: 'Rapport du scenario'
+    },
     reportId: '608b7bef-f5e3-4aae-b8db-19bbb38325d5',
     settings: {
       navContentPaneEnabled: false,
@@ -81,7 +84,10 @@ export const SCENARIO_DASHBOARD_CONFIG = [
 // https://github.com/microsoft/powerbi-models
 export const DASHBOARDS_LIST_CONFIG = [
   {
-    title: 'Digital Twin Structure',
+    title: {
+      en: 'Digital Twin Structure',
+      fr: 'Structure du jumeau numérique'
+    },
     reportId: '608b7bef-f5e3-4aae-b8db-19bbb38325d5',
     settings: {
       navContentPaneEnabled: false,
@@ -106,7 +112,10 @@ export const DASHBOARDS_LIST_CONFIG = [
     }
   },
   {
-    title: 'Stocks Follow-up',
+    title: {
+      en: 'Stocks Follow-up',
+      fr: 'Suivi de stock'
+    },
     reportId: '608b7bef-f5e3-4aae-b8db-19bbb38325d5',
     settings: {
       navContentPaneEnabled: false,
@@ -131,7 +140,10 @@ export const DASHBOARDS_LIST_CONFIG = [
     }
   },
   {
-    title: 'Customer Satisfaction',
+    title: {
+      en: 'Customer Satisfaction',
+      fr: 'Satisfaction cliente'
+    },
     reportId: '608b7bef-f5e3-4aae-b8db-19bbb38325d5',
     settings: {
       navContentPaneEnabled: false,

--- a/src/configs/App.config.js
+++ b/src/configs/App.config.js
@@ -142,7 +142,7 @@ export const DASHBOARDS_LIST_CONFIG = [
   {
     title: {
       en: 'Customer Satisfaction',
-      fr: 'Satisfaction cliente'
+      fr: 'Satisfaction client'
     },
     reportId: '608b7bef-f5e3-4aae-b8db-19bbb38325d5',
     settings: {

--- a/src/views/Dashboards/Dashboards.js
+++ b/src/views/Dashboards/Dashboards.js
@@ -26,6 +26,8 @@ const useStyles = makeStyles(theme => ({
   }
 }));
 
+const DEFAULT_MISSING_TITLE = 'MISSING_TITLE_IN_LANGUAGE';
+
 function a11yProps (index) {
   return {
     id: `vertical-tab-${index}`,
@@ -42,7 +44,7 @@ const Dashboards = ({ currentScenario, scenarioList, reports }) => {
     setValue(newValue);
   };
 
-  const dashboardTitle = DASHBOARDS_LIST_CONFIG[value].title[i18n.language];
+  const dashboardTitle = DASHBOARDS_LIST_CONFIG[value].title[i18n.language] === undefined ? DEFAULT_MISSING_TITLE : DASHBOARDS_LIST_CONFIG[value].title[i18n.language];
 
   return (
     <Grid container className={classes.root} direction="row">
@@ -122,7 +124,7 @@ function TabPanel (props) {
 const constructDashboardTabs = (i18n) => {
   const tabs = [];
   for (const dashboardConf of DASHBOARDS_LIST_CONFIG) {
-    const dashboardTitle = dashboardConf.title[i18n.language];
+    const dashboardTitle = dashboardConf.title[i18n.language] === undefined ? DEFAULT_MISSING_TITLE : dashboardConf.title[i18n.language];
     tabs.push(<Tab key={dashboardTitle} label={dashboardTitle} {...a11yProps(dashboardConf.id)} />);
   }
   return tabs;

--- a/src/views/Dashboards/Dashboards.js
+++ b/src/views/Dashboards/Dashboards.js
@@ -42,6 +42,8 @@ const Dashboards = ({ currentScenario, scenarioList, reports }) => {
     setValue(newValue);
   };
 
+  const dashboardTitle = DASHBOARDS_LIST_CONFIG[value].title[i18n.language];
+
   return (
     <Grid container className={classes.root} direction="row">
       <Grid item sm={2}>
@@ -56,9 +58,7 @@ const Dashboards = ({ currentScenario, scenarioList, reports }) => {
             aria-label="Dashboards list"
             className={classes.tabs}
           >
-            {DASHBOARDS_LIST_CONFIG.map(dashboard => (
-              <Tab key={dashboard.title} label={dashboard.title} {...a11yProps(dashboard.id)} />
-            ))}
+            {constructDashboardTabs(i18n)}
           </Tabs>
         </Card>
       </Grid>
@@ -68,8 +68,8 @@ const Dashboards = ({ currentScenario, scenarioList, reports }) => {
               <TabPanel
                 className={classes.dashboard}
                 index={value}
-                key={DASHBOARDS_LIST_CONFIG[value].id}
-                title={DASHBOARDS_LIST_CONFIG[value].title}
+                key={dashboardTitle}
+                title={dashboardTitle}
                 reports={reports}
                 scenario={currentScenario}
                 scenarioList={scenarioList.data}
@@ -118,6 +118,15 @@ function TabPanel (props) {
     </div>
   );
 }
+
+const constructDashboardTabs = (i18n) => {
+  const tabs = [];
+  for (const dashboardConf of DASHBOARDS_LIST_CONFIG) {
+    const dashboardTitle = dashboardConf.title[i18n.language];
+    tabs.push(<Tab key={dashboardTitle} label={dashboardTitle} {...a11yProps(dashboardConf.id)} />);
+  }
+  return tabs;
+};
 
 TabPanel.propTypes = {
   children: PropTypes.node,

--- a/src/views/Dashboards/README.md
+++ b/src/views/Dashboards/README.md
@@ -8,7 +8,7 @@ To add an entry in the Dashboards view menu:
 - Add a new object in the existing DASHBOARDS_LIST_CONFIG array, respecting the following pattern:
 ```
   {
-    title: '<title>',                     // Dashboard's title that appears in left tabs,
+    title: '<title object>',              // Dashboard's title that appears in left tabs (e.g. {en: 'title in English', fr: 'Titre en français' } )
     reportId: <report unique id>,         // You can get the report Id in PowerBI 
     settings: '<settings object>',        // a settings object see https://github.com/microsoft/powerbi-models/blob/0d326572c4253fd9f89b73a0d8df1ae46318a860/src/models.ts#L1070
     staticFilters?: <filters array>,      // an array of PowerBIReportEmbedSimpleFilter and/or PowerBIReportEmbedMultipleFilter from @cosmotech/core dependency         


### PR DESCRIPTION
Adapt DASHBOARDS_LIST_CONFIG/SCENARIO_DASHBOARD_CONFIG structure to add language in title parameter
Add constructDashboardTabs function in Dashboards view
Adapt README.md in for Dashboards

Dev Review rules:
- 3 PR max
- at the second feedback, prefer meet instead of github conversation

Definition of Done:
- [X] Testing
- [X] No error logs in web console (except iFrame errors)
- [X] Create or Update documentation (README file for users/integrators)
- [X] Check the [test page](https://spaceport.cosmotech.com/confluence/pages/viewpage.action?spaceKey=QA&title=Azure+Sample+Webapp) in order to manually validate the feature 
- [X] Clean code (regroup configuration variable, typos, no console.log...)
