### PR TITLE
feat: Add scenario's name in delete confirmation dialog

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -164,7 +164,7 @@
             "confirm": "Confirm"
           },
           "description": "This operation is irreversible. Dataset(s) will not be removed, but the scenario parameters will be lost. If this scenario has children, they will be moved to a new parent. The new parent will be the parent of the deleted scenario.",
-          "title": "Remove selected scenario?"
+          "title": "Remove scenario '{{scenarioName}}'?"
         }
       },
       "create": {

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -164,7 +164,7 @@
             "confirm": "Confirmer"
           },
           "description": "Cette opération est irréversible. Les datasets ne seront pas supprimés, mais les paramètres du scénario seront perdus. Si le scénario a des enfants, ils seront remontés d'un niveau dans la hiérarchie des scénarios.",
-          "title": "Confirmer la suppression du scénario ?"
+          "title": "Confirmer la suppression du scénario '{{scenarioName}}' ?"
         }
       },
       "create": {

--- a/src/views/ScenarioManager/ScenarioManager.js
+++ b/src/views/ScenarioManager/ScenarioManager.js
@@ -57,13 +57,18 @@ const ScenarioManager = (props) => {
     return t('commoncomponents.scenariomanager.treelist.node.dataset', { count: datasetList?.length || 0 });
   }
 
+  function buildScenarioNameToDelete(scenarioName) {
+    return t('commoncomponents.dialog.confirm.delete.title', "Remove scenario '{{scenarioName}}'?", {
+      scenarioName,
+    });
+  }
+
   const labels = {
     status: t('commoncomponents.scenariomanager.treelist.node.status.label'),
     successful: t('commoncomponents.scenariomanager.treelist.node.status.successful'),
     failed: t('commoncomponents.scenariomanager.treelist.node.status.failed'),
     created: t('commoncomponents.scenariomanager.treelist.node.status.created'),
     deleteDialog: {
-      title: t('commoncomponents.dialog.confirm.delete.title', 'Confirm delete?'),
       description: t(
         'commoncomponents.dialog.confirm.delete.description',
         'The scenario will be deleted. If this scenario has children, ' +
@@ -87,6 +92,7 @@ const ScenarioManager = (props) => {
         buildSearchInfo={buildSearchInfoLabel}
         buildDatasetInfo={buildDatasetLabel}
         labels={labels}
+        buildScenarioNameToDelete={buildScenarioNameToDelete}
       />
     </div>
   );


### PR DESCRIPTION
Dev Review rules:
- 3 PR max
- at the second feedback, prefer meet instead of github conversation

Definition of Done:
- [ ] Testing
- [ ] No error logs in web console (except iFrame errors)
- [ ] Create or Update documentation (README file for users/integrators)
- [ ] Check the [test page](https://spaceport.cosmotech.com/confluence/pages/viewpage.action?spaceKey=QA&title=Azure+Sample+Webapp) in order to manually validate the feature 
- [ ] Clean code (regroup configuration variable, typos, no console.log...)
