### PR TITLE
fix: fix empty field when typing zero in a number input

### DIFF
--- a/src/utils/scenarioParameters/factories/inputComponentsFactories/BasicNumberInputFactory.js
+++ b/src/utils/scenarioParameters/factories/inputComponentsFactories/BasicNumberInputFactory.js
@@ -38,12 +38,17 @@ const create = (t, parameterData, parametersState, setParametersState, editMode)
     });
   }
 
+  let value = parametersState[parameterData.id];
+  if (value == null) {
+    value = NaN;
+  }
+
   return (
     <BasicNumberInput
       key={parameterData.id}
       data-cy={parameterData.dataCy}
       label={t(`solution.parameters.${parameterData.id}`, parameterData.id)}
-      value={parametersState[parameterData.id] || NaN}
+      value={value}
       changeNumberField={setValue}
       textFieldProps={textFieldProps}
       inputProps={inputProps}


### PR DESCRIPTION
It was also impossible to enter values between -1 and 1,
these values were rounded to zero and fell into the same bug.