### PR TITLE
Esas/runtype dependents scenario report

### DIFF
--- a/doc/dashboards.md
+++ b/doc/dashboards.md
@@ -2,16 +2,17 @@
 
 In the web application, the _Scenario_ and _Dashboards_ pages allow you to embed [PowerBI](https://powerbi.microsoft.com/fr-fr/getting-started-with-power-bi/) reports.
 
-The Scenario view will allow a single report, that is supposed to display the results of the currently selected
-scenario, after it has run. The Dashboards view offers a menu to let users switch between several reports, that can
+In Scenario view PowerBI report is supposed to display the results of the currently selected scenario, after it has run; 
+you can set a specific configuration for each run template or a general one for all scenarios.
+
+The Dashboards view offers a menu to let users switch between several reports, that can
 typically be used for in-depth results analysis or to compare the results of several scenarios.
 
 ## Dashboards configuration
 
 You can configure the dashboards to be used in your webapp by exporting the constants **_SCENARIO_DASHBOARD_CONFIG_**
 (for the Scenario view) and **_DASHBOARDS_LIST_CONFIG_** (for the Dashboards view) in the file
-[src/config/Dashboards.js](../src/config/Dashboards.js). Both of these constants must be lists, but the
-_SCENARIO_DASHBOARD_CONFIG_ is expected to have only one element.
+[src/config/Dashboards.js](../src/config/Dashboards.js).
 
 Configuration objects inside these lists are similar for the Scenario view and for the Dashboards view:
 
@@ -26,10 +27,69 @@ Configuration objects inside these lists are similar for the Scenario view and f
     staticFilters?: <filters array>,      // an array of PowerBIReportEmbedSimpleFilter and/or PowerBIReportEmbedMultipleFilter from @cosmotech/core dependency
     dynamicFilters?: <filters array>,     // an array of PowerBIReportEmbedSimpleFilter and/or PowerBIReportEmbedMultipleFilter from @cosmotech/core dependency
     pageName: {
-      en: <english report section id>     // the report section that you want to display when current language is English
-      fr: <french report section id>      // the report section that you want to display when current language is French
+      en: <section id for english version>     // the report section that you want to display when current language is English; it can be found in the URL of your report
+      fr: <section id for french version>      // the report section that you want to display when current language is French; it can be found in the URL of your report
     }
   }
+```
+### Dashboard view
+**_DASHBOARDS_LIST_CONFIG_** must be an array with one or several configuration objects inside.
+### Scenario view
+If only one configuration will be used for all run templates, **_SCENARIO_DASHBOARD_CONFIG_** can be an array with the configuration object inside:
+```
+export const SCENARIO_DASHBOARD_CONFIG = [
+  {
+    title: {
+      en: <english title>,
+      fr: <french title>,
+      },
+    reportId: <report unique id>,
+    settings: <settings object>,
+    staticFilters: <filters array>,
+    dynamicFilters: <filters array>,
+    pageName: {
+      en: <section id for english version>,
+      fr: <section id for french version>,
+    },
+  },
+];
+```
+If the configuration differs from one run template to another, **_SCENARIO_DASHBOARD_CONFIG_** must be an object with all possible configuration objects 
+identified by runTemplateId. Note that each run template needs a specific configuration object; if the same configuration is used for several run templates,
+it can be declared in a special variable:
+```
+const defaultScenarioViewReport = {
+  title: {
+    en: <english title>,
+    fr: <french title>,
+  },
+  reportId: <report unique id>,
+  settings: <settings object>,
+  staticFilters: <filters array>,
+  dynamicFilters: <filters array>,
+  pageName: {
+    en: <section id for english version>,
+    fr: <section id for french version>,
+  },
+};
+export const SCENARIO_DASHBOARD_CONFIG = {
+  1: {
+    title: {
+      en: <english title>,
+      fr: <french title>,
+    },
+    reportId: <report unique id>,
+    settings: <settings object>,
+    staticFilters: <filters array>,
+    dynamicFilters: <filters array>,
+    pageName: {
+      en: <section id for english version>,
+      fr: <section id for french version>,
+    },
+  },
+  2: defaultScenarioViewReport,
+  3: defaultScenarioViewReport,
+};
 ```
 
 ## How to get the information for embedding with PowerBI
@@ -37,9 +97,8 @@ Configuration objects inside these lists are similar for the Scenario view and f
 Everything is available in PowerBI service URL:
 
 - you get the embedded report URL `MyReportURL`
-- in PowerBI online, look at the end of your report's URL to get the section name. It should look like `/ReportSection`
-- the values you need to use for `reportId` key and `pageName` key are then:\
-  `MyReportURL?reportId=<reportId>&pageName=<pageName>`
+- the value you need to use for `reportId` key is `MyReportURL?reportId=<reportId>`
+- to get the page name, open your report in PowerBI online, look at the end of your report's URL to get the page name. It should look like `/ReportSection`
 
 ## Report page size recommendation
 

--- a/src/config/Dashboards.js
+++ b/src/config/Dashboards.js
@@ -29,7 +29,7 @@ const defaultScenarioViewReport = {
       },
     },
   },
-  staticFilters: [new PowerBIReportEmbedMultipleFilter('Bar', 'Bar', ['MyBar'])],
+  staticFilters: [new PowerBIReportEmbedMultipleFilter('Bar', 'Bar', ['MyBar', 'MyBar2'])],
   dynamicFilters: [
     new PowerBIReportEmbedSimpleFilter('StockProbe', 'SimulationRun', POWER_BI_FIELD_ENUM.SCENARIO_CSM_SIMULATION_RUN),
     new PowerBIReportEmbedSimpleFilter('Bar', 'simulationrun', POWER_BI_FIELD_ENUM.SCENARIO_CSM_SIMULATION_RUN),
@@ -55,15 +55,15 @@ const defaultScenarioViewReport = {
     fr: 'ReportSection',
   },
 };
-export const SCENARIO_VIEW_REPORTS_BY_RUNTEMPLATE = {
+export const SCENARIO_DASHBOARD_CONFIG = {
   1: {
     title: {
       en: 'Scenario dashboard for run type 1',
       fr: 'Rapport du scenario du run type 1',
     },
-    reportId: '70ff6a53-04f9-4076-93c0-328426b78c8f',
+    reportId: '608b7bef-f5e3-4aae-b8db-19bbb38325d5',
     settings: {
-      navContentPaneEnabled: true,
+      navContentPaneEnabled: false,
       filterPaneEnabled: true,
       panes: {
         filters: {
@@ -72,7 +72,7 @@ export const SCENARIO_VIEW_REPORTS_BY_RUNTEMPLATE = {
         },
       },
     },
-    staticFilters: [new PowerBIReportEmbedMultipleFilter('Bar', 'Bar', ['MyBar'])],
+    staticFilters: [new PowerBIReportEmbedMultipleFilter('Bar', 'Bar', ['MyBar', 'MyBar2'])],
     dynamicFilters: [
       new PowerBIReportEmbedSimpleFilter(
         'StockProbe',
@@ -86,8 +86,8 @@ export const SCENARIO_VIEW_REPORTS_BY_RUNTEMPLATE = {
       ),
     ],
     pageName: {
-      en: 'ReportSection',
-      fr: 'ReportSection',
+      en: 'ReportSection937f9c72cc8f1062aa88',
+      fr: 'ReportSection937f9c72cc8f1062aa88',
     },
   },
   2: defaultScenarioViewReport,

--- a/src/config/Dashboards.js
+++ b/src/config/Dashboards.js
@@ -13,27 +13,75 @@ import {
 // https://github.com/microsoft/PowerBI-JavaScript
 // using
 // https://github.com/microsoft/powerbi-models
-export const SCENARIO_DASHBOARD_CONFIG = [
-  {
-    title: {
-      en: 'Scenario dashboard',
-      fr: 'Rapport du scenario',
+
+const defaultScenarioViewReport = {
+  title: {
+    en: 'Scenario dashboard',
+    fr: 'Rapport du scenario',
+  },
+  reportId: '608b7bef-f5e3-4aae-b8db-19bbb38325d5',
+  settings: {
+    navContentPaneEnabled: false,
+    panes: {
+      filters: {
+        expanded: false,
+        visible: false,
+      },
     },
-    reportId: '608b7bef-f5e3-4aae-b8db-19bbb38325d5',
+  },
+  staticFilters: [new PowerBIReportEmbedMultipleFilter('Bar', 'Bar', ['MyBar'])],
+  dynamicFilters: [
+    new PowerBIReportEmbedSimpleFilter('StockProbe', 'SimulationRun', POWER_BI_FIELD_ENUM.SCENARIO_CSM_SIMULATION_RUN),
+    new PowerBIReportEmbedSimpleFilter('Bar', 'simulationrun', POWER_BI_FIELD_ENUM.SCENARIO_CSM_SIMULATION_RUN),
+    new PowerBIReportEmbedSimpleFilter(
+      'contains_Customer',
+      'simulationrun',
+      POWER_BI_FIELD_ENUM.SCENARIO_CSM_SIMULATION_RUN
+    ),
+    new PowerBIReportEmbedSimpleFilter(
+      'arc_to_Customer',
+      'simulationrun',
+      POWER_BI_FIELD_ENUM.SCENARIO_CSM_SIMULATION_RUN
+    ),
+    new PowerBIReportEmbedSimpleFilter('parameters', 'simulationrun', POWER_BI_FIELD_ENUM.SCENARIO_CSM_SIMULATION_RUN),
+    new PowerBIReportEmbedSimpleFilter(
+      'CustomerSatisfactionProbe',
+      'SimulationRun',
+      POWER_BI_FIELD_ENUM.SCENARIO_CSM_SIMULATION_RUN
+    ),
+  ],
+  pageName: {
+    en: 'ReportSection',
+    fr: 'ReportSection',
+  },
+};
+export const SCENARIO_VIEW_REPORTS_BY_RUNTEMPLATE = {
+  1: {
+    title: {
+      en: 'Scenario dashboard for run type 1',
+      fr: 'Rapport du scenario du run type 1',
+    },
+    reportId: '70ff6a53-04f9-4076-93c0-328426b78c8f',
     settings: {
-      navContentPaneEnabled: false,
+      navContentPaneEnabled: true,
+      filterPaneEnabled: true,
       panes: {
         filters: {
-          expanded: false,
-          visible: false,
+          expanded: true,
+          visible: true,
         },
       },
     },
-    staticFilters: [new PowerBIReportEmbedMultipleFilter('Bar', 'id', ['MyBar', 'MyBar2'])],
+    staticFilters: [new PowerBIReportEmbedMultipleFilter('Bar', 'Bar', ['MyBar'])],
     dynamicFilters: [
       new PowerBIReportEmbedSimpleFilter(
         'StockProbe',
         'SimulationRun',
+        POWER_BI_FIELD_ENUM.SCENARIO_CSM_SIMULATION_RUN
+      ),
+      new PowerBIReportEmbedSimpleFilter(
+        'contains_Customer',
+        'simulationrun',
         POWER_BI_FIELD_ENUM.SCENARIO_CSM_SIMULATION_RUN
       ),
     ],
@@ -42,8 +90,9 @@ export const SCENARIO_DASHBOARD_CONFIG = [
       fr: 'ReportSection',
     },
   },
-];
-
+  2: defaultScenarioViewReport,
+  3: defaultScenarioViewReport,
+};
 // For further information about settings or filters see:
 // https://github.com/microsoft/powerbi-client-react
 // based on

--- a/src/views/Scenario/Scenario.js
+++ b/src/views/Scenario/Scenario.js
@@ -21,7 +21,7 @@ import {
   USE_POWER_BI_WITH_USER_CREDENTIALS,
   SCENARIO_VIEW_IFRAME_DISPLAY_RATIO,
 } from '../../config/AppConfiguration';
-import { SCENARIO_DASHBOARD_CONFIG } from '../../config/Dashboards';
+import { SCENARIO_VIEW_REPORTS_BY_RUNTEMPLATE } from '../../config/Dashboards';
 import ScenarioService from '../../services/scenario/ScenarioService';
 import ScenarioRunService from '../../services/scenarioRun/ScenarioRunService';
 import { STATUSES } from '../../state/commons/Constants';
@@ -61,6 +61,11 @@ const Scenario = (props) => {
   const createScenarioDialogLabels = getCreateScenarioDialogLabels(t, editMode);
   const reportLabels = getReportLabels(t);
 
+  // Get the right report for given run template
+  const defaultPowerBIREport = Object.keys(SCENARIO_VIEW_REPORTS_BY_RUNTEMPLATE)[0];
+  const currentScenarioRunTemplateReport = Array.isArray(SCENARIO_VIEW_REPORTS_BY_RUNTEMPLATE)
+    ? SCENARIO_VIEW_REPORTS_BY_RUNTEMPLATE
+    : [SCENARIO_VIEW_REPORTS_BY_RUNTEMPLATE[currentScenario?.data?.runTemplateId ?? defaultPowerBIREport]];
   // Add accordion expand status in state
   const [accordionSummaryExpanded, setAccordionSummaryExpanded] = useState(
     localStorage.getItem('scenarioParametersAccordionExpanded') === 'true'
@@ -323,8 +328,9 @@ const Scenario = (props) => {
       </Grid>
       <Card>
         <SimplePowerBIReportEmbed
+          key={currentScenario.data.id}
           reports={reports}
-          reportConfiguration={SCENARIO_DASHBOARD_CONFIG}
+          reportConfiguration={currentScenarioRunTemplateReport}
           scenario={currentScenario.data}
           lang={i18n.language}
           downloadLogsFile={currentScenario.data?.lastRun ? downloadLogsFile : null}

--- a/src/views/Scenario/Scenario.js
+++ b/src/views/Scenario/Scenario.js
@@ -21,7 +21,7 @@ import {
   USE_POWER_BI_WITH_USER_CREDENTIALS,
   SCENARIO_VIEW_IFRAME_DISPLAY_RATIO,
 } from '../../config/AppConfiguration';
-import { SCENARIO_VIEW_REPORTS_BY_RUNTEMPLATE } from '../../config/Dashboards';
+import { SCENARIO_DASHBOARD_CONFIG } from '../../config/Dashboards';
 import ScenarioService from '../../services/scenario/ScenarioService';
 import ScenarioRunService from '../../services/scenarioRun/ScenarioRunService';
 import { STATUSES } from '../../state/commons/Constants';
@@ -62,10 +62,10 @@ const Scenario = (props) => {
   const reportLabels = getReportLabels(t);
 
   // Get the right report for given run template
-  const defaultPowerBIREport = Object.keys(SCENARIO_VIEW_REPORTS_BY_RUNTEMPLATE)[0];
-  const currentScenarioRunTemplateReport = Array.isArray(SCENARIO_VIEW_REPORTS_BY_RUNTEMPLATE)
-    ? SCENARIO_VIEW_REPORTS_BY_RUNTEMPLATE
-    : [SCENARIO_VIEW_REPORTS_BY_RUNTEMPLATE[currentScenario?.data?.runTemplateId ?? defaultPowerBIREport]];
+  const defaultPowerBIReport = Object.keys(SCENARIO_DASHBOARD_CONFIG)[0];
+  const currentScenarioRunTemplateReport = Array.isArray(SCENARIO_DASHBOARD_CONFIG)
+    ? SCENARIO_DASHBOARD_CONFIG
+    : [SCENARIO_DASHBOARD_CONFIG[currentScenario?.data?.runTemplateId ?? defaultPowerBIReport]];
   // Add accordion expand status in state
   const [accordionSummaryExpanded, setAccordionSummaryExpanded] = useState(
     localStorage.getItem('scenarioParametersAccordionExpanded') === 'true'
@@ -328,7 +328,9 @@ const Scenario = (props) => {
       </Grid>
       <Card>
         <SimplePowerBIReportEmbed
-          key={currentScenario.data.id}
+          // key is used here to assure the complete re-rendering of the component when scenario changes ;
+          // we need to remount it to avoid errors in powerbi-client-react which throws an error if filters change
+          key={currentScenario?.data?.id}
           reports={reports}
           reportConfiguration={currentScenarioRunTemplateReport}
           scenario={currentScenario.data}


### PR DESCRIPTION
Change dashboard config file (src/config/Dashboard.js) :
replace SCENARIO_DASHBOARD_CONFIG with SCENARIO_VIEW_REPORTS_BY_RUNTEMPLATE.
The new config contains all possible dashboards for the project ; every dashboard contains possible filters and other options and is identified with a key that corresponds to currentScenario.data.runTemplateId in Redux. If the same config is used for several runTemplates, it must be declared for each runTemplate (in the defaultScenarioReport variable for example). 

Then, in Scenario view (/src/views/Scenario/Scenario.js), the config is stored in the currentScenarioRunTemplateReport array that helps distinguish new config from old one (for backward compatibility currentScenarioRunTemplateReport must be an array to be compatible with existing SimplePowerBIReportEmbed component(cosmotech/ui library)) : if the old one, the entire config object is assigned to currentScenarioRunTemplateReport, if new one, the SCENARIO_VIEW_REPORTS_BY_RUNTEMPLATE array is filtered for runTemplateId and the result is pushed in currentScenarioViewReport. To avoid app crash when there is no scenario, the first report in the list is declared as defaultPowerBIReport.

The powerbi-client-react actually uses setFilters() and removeFilters() methods to update the configuration while Microsoft recommends the general updateFilters() method : https://docs.microsoft.com/en-us/javascript/api/overview/powerbi/control-report-filters#update-filters
  This causes an undefined error in console nevertheless the config is updated properly. To avoid any confusion or future incompatibility, the embed component is destroyed and rerendered when a scenario changes.

Dev Review rules:
- 3 PR max
- at the second feedback, prefer meet instead of github conversation

Definition of Done:
- [ ] Testing
- [ ] No error logs in web console (except iFrame errors)
- [ ] Create or Update documentation (README file for users/integrators)
- [ ] Identify breaking changes with [conventional commits](https://kapeli.com/cheat_sheets/Conventional_Commits.docset/Contents/Resources/Documents/index)
- [ ] Check the [test page](https://spaceport.cosmotech.com/confluence/pages/viewpage.action?spaceKey=QA&title=Azure+Sample+Webapp) in order to manually validate the feature
- [ ] Clean code (regroup configuration variable, typos, no console.log...)
