### PR TITLE
feat: dashed style for out-edges, 2 new selectors to apply style

### DIFF
--- a/src/views/Instance/data.js
+++ b/src/views/Instance/data.js
@@ -8,6 +8,7 @@ import {
   getDefaultNodeStyle,
   getDefaultSelectedEdgeStyle,
   getDefaultSelectedNodeStyle,
+  getDefaultOutEdgeStyle,
 } from './styleCytoViz';
 import { ORGANIZATION_ID, WORKSPACE_ID } from '../../config/GlobalConfiguration';
 import instanceViewData from '../../config/InstanceVisualization.js';
@@ -87,6 +88,14 @@ const _processGraphEdges = (processedData, datasetContent, edgesGroups, theme) =
     processedData.stylesheet.push({
       selector: `edge.${edgesGroupName}:selected`,
       style: { ...getDefaultSelectedEdgeStyle(theme), ...edgesGroupMetadata.style },
+    });
+    processedData.stylesheet.push({
+      selector: 'edge[?asInEdgeHighlighted]',
+      style: { ...getDefaultSelectedEdgeStyle(theme), ...edgesGroupMetadata.style },
+    });
+    processedData.stylesheet.push({
+      selector: 'edge[?asOutEdgeHighlighted]',
+      style: { ...getDefaultOutEdgeStyle(theme), ...edgesGroupMetadata.style },
     });
   });
 };

--- a/src/views/Instance/styleCytoViz.js
+++ b/src/views/Instance/styleCytoViz.js
@@ -10,18 +10,27 @@ const NODE_SELECTED_ICON_SIZE = '34';
 const NODE_SELECTED_BLACKEN_RATIO = 0.1;
 // Edges
 const EDGE_DEFAULT_COLOR = '#999999';
-const EDGE_SELECTED_WIDTH = 3.5;
+const EDGE_SELECTED_COLOR = '#5b5b5b';
+const EDGE_SELECTED_WIDTH = 5;
 const EDGE_WIDTH = 2;
 
 // Styles details
 export const getDefaultEdgeStyle = (theme) => ({
   'line-color': EDGE_DEFAULT_COLOR,
+  'curve-style': 'bezier',
   width: EDGE_WIDTH,
 });
 
 export const getDefaultSelectedEdgeStyle = (theme) => ({
   ...getDefaultEdgeStyle(theme),
   width: EDGE_SELECTED_WIDTH,
+  'line-color': EDGE_SELECTED_COLOR,
+});
+export const getDefaultOutEdgeStyle = (theme) => ({
+  ...getDefaultEdgeStyle(theme),
+  width: EDGE_SELECTED_WIDTH,
+  'line-color': EDGE_SELECTED_COLOR,
+  'line-style': 'dashed',
 });
 
 export const getDefaultNodeStyle = (theme) => ({


### PR DESCRIPTION
- new style for default out edge style (dashed)
- new selector to apply new default edge style
- 'curve-style': 'bezier' to be able to differentiate between in, out edges when graph is symmetric.