### PR TITLE
feat: colors by class on the fly,added shiny style option in Instance…

### DIFF
--- a/src/config/InstanceVisualization.js
+++ b/src/config/InstanceVisualization.js
@@ -1,6 +1,6 @@
 // Copyright (c) Cosmo Tech.
 // Licensed under the MIT license.
-
+const APPLY_SHINY_STYLE = true;
 const DATA_SOURCE = {
   type: 'adt',
   // functionUrl: 'http://localhost:7071/api/ScenarioDownload', // Use for a local azure function
@@ -9,19 +9,17 @@ const DATA_SOURCE = {
 };
 
 const DATA_CONTENT = {
+  shinyStyle: APPLY_SHINY_STYLE,
   compounds: {
     contains_Customer: {},
   },
   edges: {
-    arc_to_Customer: { style: { 'line-color': '#999999' }, selectable: false },
+    arc_to_Customer: { selectable: true },
   },
   nodes: {
     Bar: {
       style: {
         shape: 'rectangle',
-        'background-color': '#466282',
-        'background-opacity': 0.2,
-        'border-width': 0,
       },
       pannable: true,
       selectable: true,
@@ -29,7 +27,6 @@ const DATA_CONTENT = {
     },
     Customer: {
       style: {
-        'background-color': '#005A31',
         shape: 'ellipse',
       },
     },

--- a/src/views/Instance/styleCytoViz.js
+++ b/src/views/Instance/styleCytoViz.js
@@ -10,8 +10,39 @@ const NODE_SELECTED_ICON_SIZE = '34';
 const NODE_SELECTED_BLACKEN_RATIO = 0.1;
 // Edges
 const EDGE_DEFAULT_COLOR = '#999999';
+const EDGE_SELECTED_COLOR = '#5b5b5b';
 const EDGE_SELECTED_WIDTH = 3.5;
 const EDGE_WIDTH = 2;
+const EDGE_WIDTH_SHINY = 4;
+const EDGE_SELCTED_WIDTH_SHINY = 6;
+
+export const shinyColors = [
+  '#5F95FF', // blue
+  '#61DDAA', // green
+  '#ffb039', // cosmogold
+  '#F08BB4', // pink
+  '#F6BD16', // orange
+  '#7262FD', // blue
+  '#78D3F8', // azure
+  '#9661BC', // purple
+  '#F6903D', // orange
+];
+
+export const getAssociatedClassAttribute = (attributesToAssign, currentElementGroup, associationMap) => {
+  if (!associationMap.has(currentElementGroup)) {
+    const usedAttributesArray = Array.from(associationMap.values());
+    const freeAttributes = attributesToAssign.filter((val) => !usedAttributesArray.includes(val));
+    if (freeAttributes.length > 0) {
+      associationMap.set(currentElementGroup, freeAttributes[0]);
+    } else {
+      associationMap.set(currentElementGroup, attributesToAssign[0]);
+      console.log(
+        `The amount of elemet classes is bigger then the possible attributes so attributes will be used multiple times`
+      );
+    }
+  }
+  return associationMap.get(currentElementGroup);
+};
 
 // Styles details
 export const getDefaultEdgeStyle = (theme) => ({
@@ -22,6 +53,7 @@ export const getDefaultEdgeStyle = (theme) => ({
 export const getDefaultSelectedEdgeStyle = (theme) => ({
   ...getDefaultEdgeStyle(theme),
   width: EDGE_SELECTED_WIDTH,
+  'line-color': EDGE_SELECTED_COLOR,
 });
 
 export const getDefaultNodeStyle = (theme) => ({
@@ -42,4 +74,56 @@ export const getDefaultSelectedNodeStyle = (theme) => ({
   width: NODE_SELECTED_ICON_SIZE,
   height: NODE_SELECTED_ICON_SIZE,
   'background-blacken': -NODE_SELECTED_BLACKEN_RATIO,
+});
+
+export const getDefaultCompoundNodeStyle = (theme) => ({
+  'border-color': EDGE_DEFAULT_COLOR,
+  'border-width': 0,
+  'background-color': '#466282',
+  'background-opacity': 0.2,
+});
+
+// Shiny styles
+export const getShinyEdgeStyle = (theme) => ({
+  'line-color': EDGE_DEFAULT_COLOR,
+  'target-arrow-color': EDGE_DEFAULT_COLOR,
+  width: EDGE_WIDTH_SHINY,
+  'target-arrow-shape': 'triangle',
+  'curve-style': 'bezier',
+});
+
+export const getShinySelectedEdgeStyle = (theme) => ({
+  ...getShinyEdgeStyle(theme),
+  width: EDGE_SELCTED_WIDTH_SHINY,
+  'line-color': theme.palette.type === 'light' ? EDGE_SELECTED_COLOR : '#fff',
+  // needs to depend the theme bright theme => edges rest gray, little darker, if dark: edges white
+  'target-arrow-color': theme.palette.type === 'light' ? EDGE_SELECTED_COLOR : '#fff',
+  'target-arrow-shape': 'triangle',
+  'curve-style': 'bezier',
+});
+
+export const getShinyNodeStyle = (theme) => ({
+  width: NODE_ICON_SIZE,
+  height: NODE_ICON_SIZE,
+  'background-opacity': 0.2,
+  'border-width': 3,
+  'border-opacity': 0.85,
+  'font-size': NODE_LABEL_SIZE,
+  'text-max-width': NODE_LABEL_MAX_WIDTH,
+  'text-wrap': 'wrap',
+  'min-zoomed-font-size': 5,
+  color: theme.palette.text.primary,
+  label: 'data(label)',
+});
+
+export const getShinySelectedNodeStyle = (theme) => ({
+  ...getShinyNodeStyle(theme),
+  'background-opacity': 0.85,
+});
+
+export const getShinyCompoundNodeStyle = (theme) => ({
+  'border-style': 'dashed',
+  'border-color': EDGE_DEFAULT_COLOR,
+  'border-width': 3,
+  'background-opacity': 0,
 });


### PR DESCRIPTION
- added _shiny_ styles, which are applied depending on the state of the **APPLY_SHINY_STYLE** parameter.
- new method to attribute colors (or other attributes) from a set of attributes to elements (eg: nodes) so that two nodes of a different class don't share the given attribute
- when the user wants to use the _shiny_ style and attribute custom colors to the nodes, he must specify : 'background-color': as well as 'border-color': 