### PR TITLE
THU/fix_scenario_switch_backdrop

### DIFF
--- a/src/state/sagas/scenario/FindScenarioById/FindScenarioByIdData.js
+++ b/src/state/sagas/scenario/FindScenarioById/FindScenarioByIdData.js
@@ -39,6 +39,10 @@ export function* fetchScenarioByIdForInitialData(workspaceId, scenarioId) {
 
 export function* fetchScenarioByIdData(action) {
   try {
+    yield put({
+      type: SCENARIO_ACTIONS_KEY.SET_CURRENT_SCENARIO,
+      status: STATUSES.LOADING,
+    });
     const { data } = yield call(Api.Scenarios.findScenarioById, ORGANIZATION_ID, action.workspaceId, action.scenarioId);
     data.parametersValues = formatParametersFromApi(data.parametersValues);
     yield put({

--- a/src/views/Instance/Instance.js
+++ b/src/views/Instance/Instance.js
@@ -5,7 +5,6 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
 import { CytoViz, HierarchicalComboBox } from '@cosmotech/ui';
-import { Backdrop, CircularProgress } from '@material-ui/core';
 import { sortScenarioList } from '../../utils/SortScenarioListUtils';
 import { parseError } from '../../utils/ErrorsUtils';
 import { STATUSES } from '../../state/commons/Constants';
@@ -44,7 +43,7 @@ const Instance = (props) => {
   const noScenario = currentScenario.data === null;
   const scenarioListDisabled = scenarioList === null || noScenario;
   const scenarioListLabel = noScenario ? null : t('views.scenario.dropdown.scenario.label', 'Scenario');
-  const showBackdrop = currentScenario.status === STATUSES.LOADING;
+  const isSwitchingScenario = currentScenario.status === STATUSES.LOADING;
 
   useEffect(() => {
     // Note that the "active" variable is necessary to prevent race conditions when the effect is called several times
@@ -138,9 +137,6 @@ const Instance = (props) => {
 
   return (
     <>
-      <Backdrop className={classes.backdrop} open={showBackdrop}>
-        <CircularProgress color="inherit" />
-      </Backdrop>
       <div className={classes.mainGrid}>
         <div className={classes.scenarioSelectGridItem}>
           <HierarchicalComboBox
@@ -157,7 +153,7 @@ const Instance = (props) => {
             elements={graphElements}
             error={errorBannerMessage}
             labels={cytoVizLabels}
-            loading={isLoadingData}
+            loading={isSwitchingScenario || isLoadingData}
             extraLayouts={EXTRA_LAYOUTS}
             defaultSettings={defaultSettings}
             placeholderMessage={cytoVizPlaceholderMessage}

--- a/src/views/Scenario/Scenario.js
+++ b/src/views/Scenario/Scenario.js
@@ -301,7 +301,7 @@ const Scenario = (props) => {
   };
   return (
     <>
-      <Backdrop open={showBackdrop}>
+      <Backdrop open={showBackdrop} style={{ zIndex: '10000' }}>
         <CircularProgress color="inherit" />
       </Backdrop>
       <div data-cy="scenario-view" className={classes.content}>


### PR DESCRIPTION
- fix z-index of backdrop on scenario creation
- fix backdrop that wasn't displayed anymore when switching between scenarios
- refactor Instance view to prevent two loading spinners from being displayed: use `isLoading` prop of CytoViz component instead of adding another Backdrop in the view