### PR TITLE
Fix/scenario view bugs and warnings

### DIFF
--- a/src/state/reducers/scenario/ScenarioReducer.js
+++ b/src/state/reducers/scenario/ScenarioReducer.js
@@ -64,7 +64,7 @@ export const currentScenarioReducer = createReducer(currentScenarioInitialState,
       state.status = STATUSES.IDLE;
     })
     .addCase(SCENARIO_ACTIONS_KEY.SET_CURRENT_SCENARIO, (state, action) => {
-      if (action.scenario !== null) {
+      if ((state.data !== null && action.scenario !== null) || (state.data === null && action.scenario != null)) {
         state.data = {
           ...state.data,
           ...action.scenario,
@@ -72,7 +72,7 @@ export const currentScenarioReducer = createReducer(currentScenarioInitialState,
       } else {
         state.data = null;
       }
-      state.status = action.status;
+      state.status = action.status ?? state.status;
     })
     .addCase(SCENARIO_ACTIONS_KEY.UPDATE_SCENARIO, (state, action) => {
       // Replace state and lastRun in data if the scenario to update is currently selected

--- a/src/state/sagas/scenario/FindScenarioById/FindScenarioByIdData.js
+++ b/src/state/sagas/scenario/FindScenarioById/FindScenarioByIdData.js
@@ -72,6 +72,12 @@ export function* fetchScenarioByIdData(action) {
         t('views.scenario.redirectError.comment', 'You have been redirected to default Scenario view')
       )
     );
+    // Redirection is handled by a useEffect in the Scenario view. For this saga, we can consider that the status is
+    // now SUCCESS in the redux state for current scenario
+    yield put({
+      type: SCENARIO_ACTIONS_KEY.SET_CURRENT_SCENARIO,
+      status: STATUSES.SUCCESS,
+    });
   }
 }
 

--- a/src/views/Scenario/Scenario.js
+++ b/src/views/Scenario/Scenario.js
@@ -352,11 +352,9 @@ const Scenario = (props) => {
               )}
             </Grid>
           </Grid>
-          {currentScenario.data && (
-            <Grid item xs={4} className={classes.alignRight}>
-              {scenarioValidationArea}
-            </Grid>
-          )}
+          <Grid item xs={4} className={classes.alignRight}>
+            {currentScenario.data && scenarioValidationArea}
+          </Grid>
           <Grid item xs={12}>
             <Card component={Paper} elevation={2}>
               {currentScenario.data && (


### PR DESCRIPTION
- remove loading spinner stuck after 'wrong scenario URL' redirection

- fix scenario view layout when no scenarios exist
      Scenario selector component was stuck to the right side instead of
      being centered when no scenarios existed. An empty div for the
      scenario validation status is now always in the DOM as a placeholder
      event if the buttons inside are not visible.

- fix console warning about undefined scenarioId on scenario creation
      When modifying the scenario data:
        - allow undefined action.scenario if state.data is not null to change
           the state status without changing the current scenario data
        - prevent null and undefined action.scenario if state.data is null
      Also, if action.status is null or undefined, keep the previous status