### PR TITLE
refactor: remove unnecessary call to back-end

### DIFF
--- a/cypress/commons/actions/generic/Login.js
+++ b/cypress/commons/actions/generic/Login.js
@@ -28,8 +28,8 @@ function login() {
     statusCode: 200,
   });
 
-  const reqName = `requestLoginGetScenario_${login.reqIndex}`;
-  cy.intercept('GET', URL_REGEX.SCENARIO_PAGE_WITH_ID).as(reqName);
+  const reqName = `requestLoginGetScenarios_${login.reqIndex}`;
+  cy.intercept('GET', URL_REGEX.SCENARIOS_LIST).as(reqName);
   ++login.reqIndex;
   Login.getMicrosoftLoginButton().click();
   cy.wait('@' + reqName, { timeout: 60 * 1000 });

--- a/cypress/integration/brewery/Router - redirection after login.spec.js
+++ b/cypress/integration/brewery/Router - redirection after login.spec.js
@@ -11,8 +11,8 @@ describe('redirection after login', () => {
       statusCode: 200,
     });
 
-    const reqName = 'requestLoginGetScenario_1';
-    cy.intercept('GET', URL_REGEX.SCENARIO_PAGE_WITH_ID).as(reqName);
+    const reqName = 'requestLoginGetScenario';
+    cy.intercept('GET', URL_REGEX.SCENARIOS_LIST).as(reqName);
     Login.getMicrosoftLoginButton().click();
     cy.wait('@' + reqName);
 

--- a/cypress/integration/brewery/Router - wrong url.spec.js
+++ b/cypress/integration/brewery/Router - wrong url.spec.js
@@ -10,8 +10,8 @@ describe('Sharing with wrong URL', () => {
       statusCode: 200,
     });
 
-    const reqName = 'requestLoginGetScenario_1';
-    cy.intercept('GET', URL_REGEX.SCENARIO_PAGE_WITH_ID).as(reqName);
+    const reqName = 'requestLoginGetScenarios';
+    cy.intercept('GET', URL_REGEX.SCENARIOS_LIST).as(reqName);
     Login.getMicrosoftLoginButton().click();
     cy.wait('@' + reqName);
 

--- a/src/state/sagas/scenario/FindScenarioById/FindScenarioByIdData.js
+++ b/src/state/sagas/scenario/FindScenarioById/FindScenarioByIdData.js
@@ -11,32 +11,6 @@ import { Api } from '../../../../services/config/Api';
 import { dispatchSetApplicationErrorMessage } from '../../../dispatchers/app/ApplicationDispatcher';
 import { t } from 'i18next';
 
-export function* fetchScenarioByIdForInitialData(workspaceId, scenarioId) {
-  try {
-    const { data } = yield call(Api.Scenarios.findScenarioById, ORGANIZATION_ID, workspaceId, scenarioId);
-    data.parametersValues = formatParametersFromApi(data.parametersValues);
-    yield put({
-      type: SCENARIO_ACTIONS_KEY.SET_CURRENT_SCENARIO,
-      status: STATUSES.SUCCESS,
-      scenario: data,
-    });
-  } catch (error) {
-    yield put(
-      dispatchSetApplicationErrorMessage(
-        error,
-        t('views.scenario.redirectError.comment', 'You have been redirected to default Scenario view')
-      )
-    );
-    yield put({
-      type: SCENARIO_ACTIONS_KEY.SET_CURRENT_SCENARIO,
-      status: STATUSES.ERROR,
-      scenario: null,
-    });
-    // Rethrow for application error management
-    throw error;
-  }
-}
-
 export function* fetchScenarioByIdData(action) {
   try {
     yield put({

--- a/src/state/sagas/scenario/FindScenarioById/index.js
+++ b/src/state/sagas/scenario/FindScenarioById/index.js
@@ -2,4 +2,3 @@
 // Licensed under the MIT license.
 
 export { default as findScenarioByIdData } from './FindScenarioByIdData';
-export { fetchScenarioByIdForInitialData } from './FindScenarioByIdData';

--- a/src/views/ScenarioManager/ScenarioManager.js
+++ b/src/views/ScenarioManager/ScenarioManager.js
@@ -73,7 +73,7 @@ const ScenarioManager = (props) => {
       if (lastScenarioDelete) {
         resetCurrentScenario();
       } else {
-        findScenarioById(WORKSPACE_ID, getFirstScenarioMaster(getScenariolistAfterDelete(scenarioId)).id);
+        setCurrentScenario(getFirstScenarioMaster(getScenariolistAfterDelete(scenarioId)));
       }
     }
   }


### PR DESCRIPTION
When opening the webapp, after receiving the list of all scenarios, we don't need to call `fetchScenarioByIdForInitialData` to write the current scenario data in redux :slightly_smiling_face: 
