### PR TITLE
chore: fix possible MSAL error showing on some webapps after enabling 2FA

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -17,7 +17,7 @@ const cspConfigPolicy = {
   'img-src': ["'self'", 'data:'],
   'style-src': ["'self'", "'unsafe-inline'"],
   'font-src': ['data:'],
-  'frame-src': ['https://app.powerbi.com', 'https://login.microsoftonline.com'],
+  'frame-src': ["'self'", 'https://app.powerbi.com', 'https://login.microsoftonline.com'],
   'manifest-src': "'self'",
 };
 

--- a/config-overrides.vanilla.js
+++ b/config-overrides.vanilla.js
@@ -16,7 +16,7 @@ const cspConfigPolicy = {
   'img-src': ["'self'", 'data:'],
   'style-src': ["'self'", "'unsafe-inline'"],
   'font-src': ['data:'],
-  'frame-src': ['https://app.powerbi.com', 'https://login.microsoftonline.com'],
+  'frame-src': ["'self'", 'https://app.powerbi.com', 'https://login.microsoftonline.com'],
   'manifest-src': "'self'",
 };
 


### PR DESCRIPTION
`'self'` has been added to the list of allowed `frame-src`