### PR TITLE
fix: [PROD-11532] Prevent useless refresh on GenericTable

### DIFF
--- a/src/components/ScenarioParameters/components/ScenarioParametersInputs/GenericTable.js
+++ b/src/components/ScenarioParameters/components/ScenarioParametersInputs/GenericTable.js
@@ -389,12 +389,14 @@ export const GenericTable = ({
 
   const onCellChange = (event) => {
     gridApiRef.current = event.api;
-    updateParameterValue({
-      status: UPLOAD_FILE_STATUS_KEY.READY_TO_UPLOAD,
-      tableDataStatus: TABLE_DATA_STATUS.READY,
-      errors: null,
-      uploadPreprocess: { content: _uploadPreprocess },
-    });
+    if (!parameter.uploadPreprocess || !isDirty) {
+      updateParameterValue({
+        status: UPLOAD_FILE_STATUS_KEY.READY_TO_UPLOAD,
+        tableDataStatus: TABLE_DATA_STATUS.READY,
+        errors: null,
+        uploadPreprocess: { content: _uploadPreprocess },
+      });
+    }
   };
 
   const onClearErrors = () => {


### PR DESCRIPTION
Before creating a PR, please check that:
- [ ] Code is clean
- [ ] Tests are still working (cypress tests and `yarn test`)
- [ ] Changes don't cause new errors or warnings in browser console
- [ ] Documentation is up-to-date
- [ ] Breaking changes are clearly identified with [conventional commits](https://kapeli.com/cheat_sheets/Conventional_Commits.docset/Contents/Resources/Documents/index)
