### PR TITLE
fix: fix console warning regarding undefined required prop

### DIFF
--- a/src/components/ScenarioParameters/components/ScenarioParametersInputs/GenericNumberInput.js
+++ b/src/components/ScenarioParameters/components/ScenarioParametersInputs/GenericNumberInput.js
@@ -77,9 +77,10 @@ GenericNumberInput.propTypes = {
   context: PropTypes.object.isRequired,
   parameterValue: PropTypes.any,
   setParameterValue: PropTypes.func.isRequired,
-  defaultParameterValue: PropTypes.number.isRequired,
+  defaultParameterValue: PropTypes.number,
   isDirty: PropTypes.bool,
 };
+
 GenericNumberInput.defaultProps = {
   isDirty: false,
 };


### PR DESCRIPTION
During transition between scenarios with different run templates, the default value for a given scenario parameter may temporarily not be available. This leads to console warnings because the defaultParameterValue prop was decalred as required. Yet, it does not need to be required: the component could use null or undefined as a default value, or wait for the actual default value to be retrieved during transitions between scenarios.