### PR TITLE
test: writeInScenarioSelectorInput check if ScenarioSelector is not d…

### DIFF
--- a/cypress/commons/actions/generic/ScenarioSelector.js
+++ b/cypress/commons/actions/generic/ScenarioSelector.js
@@ -53,9 +53,9 @@ function checkValidationStatusInScenarioSelector(searchStr, scenarioId, expected
 }
 
 function writeInScenarioSelectorInput(searchStr) {
-  return getScenarioSelectorInput()
+  getScenarioSelectorInput().should('not.be.disabled');
+  getScenarioSelectorInput()
     .click()
-    .should('not.be.disabled')
     .type(
       '{selectAll}{backspace}' + searchStr, // clear() does not always work, use "{selectAll}{backspace}" instead
       { force: true } // Force click to handle cases when the error banner is displayed above the selector options


### PR DESCRIPTION
…isabled before click

Before creating a PR, please check that:
- [ ] Code is clean
- [ ] Tests are still working (cypress tests and `yarn test`)
- [ ] Changes don't cause new errors or warnings in browser console
- [ ] Documentation is up-to-date
- [ ] Breaking changes are clearly identified with [conventional commits](https://kapeli.com/cheat_sheets/Conventional_Commits.docset/Contents/Resources/Documents/index)
