### PR TITLE
fix: disable folding of organization Accordion in workspaces selector

### DIFF
--- a/src/views/Workspaces/Workspaces.js
+++ b/src/views/Workspaces/Workspaces.js
@@ -103,7 +103,8 @@ const Workspaces = () => {
         ) : (
           <Grid container justifyContent="center" style={{ padding: '18px', height: '90%' }}>
             <Grid item xs={12}>
-              <Accordion defaultExpanded={true}>
+              {/* Keep Accordion always open while we have only one organization, and reset default cursor */}
+              <Accordion expanded={true} sx={{ '& .MuiAccordionSummary-root:hover': { cursor: 'default !important' } }}>
                 <AccordionSummary>
                   <Typography variant="body1">{organizationName}</Typography>
                 </AccordionSummary>


### PR DESCRIPTION
- disable the folding behavior of the organization `Accordion` in the workspaces selector
- reset "on hover" mouse icon to default on this accordion
  - cursor still behaves as expected when hovering the workspaces "Open" button, in the `Accordion` content
  - using `!important` in the cursor style is necessary