### PR TITLE
test: Remove console warn printing on jest test

### DIFF
--- a/src/components/CreateScenarioButton/CreateScenarioButton.spec.js
+++ b/src/components/CreateScenarioButton/CreateScenarioButton.spec.js
@@ -17,7 +17,7 @@ import { logsLabels } from './labels';
 
 const clone = rfdc();
 
-const spyConsoleWarn = jest.spyOn(console, 'warn');
+const spyConsoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
 let mockCreateScenarioUIProps;
 jest.mock('@cosmotech/ui', () => ({
   ...jest.requireActual('@cosmotech/ui'),


### PR DESCRIPTION
Before creating a PR, please check that:
- [ ] Code is clean
- [ ] Tests are still working (cypress tests and `yarn test`)
- [ ] Changes don't cause new errors or warnings in browser console
- [ ] Documentation is up-to-date
- [ ] Breaking changes are clearly identified with [conventional commits](https://kapeli.com/cheat_sheets/Conventional_Commits.docset/Contents/Resources/Documents/index)
