### PR TITLE
Thu/setup no graph placeholder

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -189,6 +189,10 @@
           "apiLink": "You can use the <1>Cosmo Tech API</1> to populate it",
           "loading": "Importing your data, please wait...",
           "noDatasetSelected": "No dataset selected. You can select a dataset in the left-side panel.",
+          "noKpis": {
+            "title": "Your dataset is ready",
+            "subtitle": "You can use it to create new scenarios"
+          },
           "unknown": "The dataset has an unknown state, if the problem persists, please, contact your administrator",
           "retryButton": "Retry",
           "rollbackButton": "Rollback"

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -189,6 +189,10 @@
           "apiLink": "Vous pouvez utiliser l'<1>API Cosmo Tech</1> pour charger des données",
           "loading": "Données en cours d'importation, veuillez patienter",
           "noDatasetSelected": "Aucun dataset sélectionné. Vous pouvez sélectionner un dataset depuis le panneau latéral gauche.",
+          "noKpis": {
+            "title": "Le dataset est prêt",
+            "subtitle": "Vous pouvez l'utiliser pour créer de nouveaux scénarios"
+          },
           "unknown": "Le dataset a un statut inconnu, si le problème persiste, merci de contacter votre administrateur",
           "retryButton": "Réessayer",
           "rollbackButton": "Restaurer"

--- a/src/views/DatasetManager/components/DatasetOverview/DatasetOverview.js
+++ b/src/views/DatasetManager/components/DatasetOverview/DatasetOverview.js
@@ -10,6 +10,12 @@ import { INGESTION_STATUS } from '../../../../services/config/ApiConstants';
 export const DatasetOverview = () => {
   const { categories, graphIndicators, queriesResults, datasetIngestionStatus, datasetName } = useDatasetOverview();
 
+  const showPlaceholder = useMemo(
+    () =>
+      datasetIngestionStatus !== INGESTION_STATUS.SUCCESS || (categories.length === 0 && graphIndicators.length === 0),
+    [categories, graphIndicators, datasetIngestionStatus]
+  );
+
   const graphIndicatorsElements = useMemo(() => {
     return graphIndicators.map((kpi) => {
       const result = queriesResults?.graphIndicators?.find((kpiResult) => kpiResult.id === kpi.id);
@@ -25,7 +31,9 @@ export const DatasetOverview = () => {
     >
       <CardHeader data-cy="dataset-name" title={datasetName} sx={{ height: '65px' }}></CardHeader>
       <CardContent sx={{ height: 'calc(100% - 65px)' }}>
-        {datasetIngestionStatus === INGESTION_STATUS.SUCCESS ? (
+        {showPlaceholder ? (
+          <DatasetOverviewPlaceholder />
+        ) : (
           <Grid container sx={{ flexFlow: 'column wrap', gap: 4 }}>
             <Grid item>
               <Grid container sx={{ flexFlow: 'row wrap', alignItems: 'stretch', justifyContent: 'center', gap: 4 }}>
@@ -38,8 +46,6 @@ export const DatasetOverview = () => {
               ))}
             </Grid>
           </Grid>
-        ) : (
-          <DatasetOverviewPlaceholder />
         )}
       </CardContent>
     </Card>

--- a/src/views/DatasetManager/components/DatasetOverview/DatasetOverviewHook.js
+++ b/src/views/DatasetManager/components/DatasetOverview/DatasetOverviewHook.js
@@ -26,8 +26,6 @@ export const useDatasetOverview = () => {
     if (config.queries == null) config.queries = [];
     return config;
   }, [workspaceData?.webApp?.options?.datasetManager]);
-  const categories = useMemo(() => datasetManagerConfig.categories, [datasetManagerConfig]);
-  const graphIndicators = useMemo(() => datasetManagerConfig.graphIndicators, [datasetManagerConfig]);
 
   initializeDatasetTwingraphQueriesResults(currentDataset);
 
@@ -42,5 +40,11 @@ export const useDatasetOverview = () => {
     return result;
   }, [workspaceData?.indicators?.categoriesKpis, workspaceData?.indicators?.graphIndicators, flatQueriesResults]);
 
-  return { categories, graphIndicators, queriesResults, datasetIngestionStatus, datasetName: currentDataset?.name };
+  return {
+    categories: datasetManagerConfig.categories,
+    graphIndicators: datasetManagerConfig.graphIndicators,
+    queriesResults,
+    datasetIngestionStatus,
+    datasetName: currentDataset?.name,
+  };
 };


### PR DESCRIPTION
- add placeholder for valid datasets when no KPIs are defined
- refactor `DatasetOverviewPlaceholder` to make it more generic, it now has 3 generic parts: a title, a row of buttons, and a subtitle