### PR TITLE
fix: change behavior when no datasets match the workspace filter

### DIFF
--- a/src/components/CreateScenarioButton/CreateScenarioButton.spec.js
+++ b/src/components/CreateScenarioButton/CreateScenarioButton.spec.js
@@ -118,25 +118,21 @@ describe('CreateScenarioButton', () => {
   });
 
   describe('Filter dataset List', () => {
-    const applyDatasetFilterToState = (state, datasetFilter) => {
-      state.workspace.current.data.linkedDatasetIdList = datasetFilter;
+    const setUpWithDatasetFilter = (linkedDatasetIdList) => {
+      const state = getStateWithWorkspaceRole(ROLES.WORKSPACE.ADMIN);
+      state.workspace.current.data.linkedDatasetIdList = linkedDatasetIdList;
+      setUp(state);
     };
 
-    const setUpWithDatasetFilter = (datasetFilter) => {
-      const initialState = getStateWithWorkspaceRole(ROLES.WORKSPACE.ADMIN);
-      applyDatasetFilterToState(initialState, datasetFilter);
-      setUp(initialState);
-    };
-
-    test('when filter is missing, datasets are filtered', () => {
+    test('when filter is missing, all datasets are shown', () => {
       setUpWithDatasetFilter(undefined);
-      expect(mockCreateScenarioUIProps.datasets).toEqual([]);
+      expect(mockCreateScenarioUIProps.datasets).toEqual(DEFAULT_REDUX_STATE.dataset.list.data);
     });
 
-    test('when filter is not an array, datasets are filtered', () => {
+    test('when filter is not an array, it is ignored and all datasets are shown', () => {
       setUpWithDatasetFilter('notAnArrayFilter');
       expect(spyConsoleWarn).toHaveBeenCalledTimes(1);
-      expect(mockCreateScenarioUIProps.datasets).toEqual([]);
+      expect(mockCreateScenarioUIProps.datasets).toEqual(DEFAULT_REDUX_STATE.dataset.list.data);
     });
 
     test('must return an empty list of datasets if the filter is an empty list', () => {
@@ -145,12 +141,10 @@ describe('CreateScenarioButton', () => {
       expect(mockCreateScenarioUIProps.datasets).toEqual([]);
     });
 
-    test('when dataset filter contains no dataset id on list it should be ignored', () => {
+    test('when dataset filter contains no dataset id on list, the resulting list should be empty', () => {
       const datasetFilter = ['fakeDatasetId1', 'fakeDatasetId2'];
       setUpWithDatasetFilter(datasetFilter);
-
-      expect(spyConsoleWarn).toHaveBeenCalledTimes(1);
-      expect(mockCreateScenarioUIProps.datasets).toEqual(DEFAULT_REDUX_STATE.dataset.list.data);
+      expect(mockCreateScenarioUIProps.datasets).toEqual([]);
     });
 
     test('when filter is present only datasets with id filtered should be present', () => {

--- a/src/hooks/WorkspaceDatasetsHooks.js
+++ b/src/hooks/WorkspaceDatasetsHooks.js
@@ -9,8 +9,7 @@ export const useWorkspaceDatasets = () => {
   const workspaceDatasetsFilter = useWorkspaceDatasetsFilter();
 
   return useMemo(() => {
-    const getMainDatasets = () => datasets.filter((dataset) => dataset.main === true);
-    if (!workspaceDatasetsFilter) return getMainDatasets();
+    if (!workspaceDatasetsFilter) return datasets;
 
     const workspaceDatasets = [];
     workspaceDatasetsFilter.forEach((filterItem) => {
@@ -21,11 +20,6 @@ export const useWorkspaceDatasets = () => {
         if (readableDataset) workspaceDatasets.push(readableDataset);
       }
     });
-
-    if (workspaceDatasetsFilter.length > 0 && workspaceDatasets.length === 0) {
-      console.warn('Ignoring datasets filter because no matching datasets have been found');
-      return getMainDatasets();
-    }
 
     return workspaceDatasets;
   }, [datasets, workspaceDatasetsFilter]);

--- a/src/state/hooks/WorkspaceHooks.js
+++ b/src/state/hooks/WorkspaceHooks.js
@@ -16,13 +16,13 @@ export const useWorkspaceDatasetsFilter = () => {
   const workspaceData = useWorkspaceData();
 
   return useMemo(() => {
-    let filter = workspaceData?.linkedDatasetIdList ?? [];
-    if (!Array.isArray(filter)) {
+    let filter = workspaceData?.linkedDatasetIdList;
+    if (filter != null && !Array.isArray(filter)) {
       console.warn('Ignoring datasets filter "linkedDatasetIdList" because it is not an array');
-      return [];
+      filter = undefined;
     }
 
-    const deprecatedFilter = workspaceData?.webApp?.options?.datasetFilter;
+    let deprecatedFilter = workspaceData?.webApp?.options?.datasetFilter;
     if (deprecatedFilter != null) {
       console.warn(
         `Deprecated option used in configuration of workspace ${workspaceData?.id}` +
@@ -30,12 +30,14 @@ export const useWorkspaceDatasetsFilter = () => {
           '.\nWorkspace key "webApp.options.datasetFilter" is deprecated. Please use the Cosmo Tech API to link ' +
           'these datasets to your workspace instead.'
       );
-      if (!Array.isArray(deprecatedFilter))
+      if (!Array.isArray(deprecatedFilter)) {
         console.warn('Ignoring deprecated option "datasetFilter" because it is not an array');
-      else filter = filter.concat(deprecatedFilter);
+        deprecatedFilter = undefined;
+      }
     }
 
-    return filter;
+    if (filter == null && deprecatedFilter == null) return undefined;
+    return (filter ?? []).concat(deprecatedFilter ?? []);
   }, [
     workspaceData?.id,
     workspaceData?.name,


### PR DESCRIPTION
The previous behavior was to show all 'main' datasets in organization when the workspace filter had no matching results. Yet, this case can happen frequently, for instance when no datasets have been shared with the webapp user: the new behavior is to show an empty dataset list in this case.