### PR TITLE
fix: fix runner logs parsing to keep only logs of main container

### DIFF
--- a/src/services/runnerRun/RunnerRunService.js
+++ b/src/services/runnerRun/RunnerRunService.js
@@ -15,7 +15,9 @@ async function downloadLogsFile(organizationId, workspaceId, runnerId, runId) {
 
     const logsParse = JSON.parse(data);
     const jsonLogs = JSON.parse(logsParse.containers.csmorchestrator.logs);
-    const parsedLogs = [jsonLogs.data.result[1].values, jsonLogs.data.result[0].values]
+    const mainContainerLogs = (jsonLogs.data.result ?? []).filter((result) => result.stream.container === 'main');
+    const parsedLogs = mainContainerLogs
+      .map((result) => result.values)
       .flat()
       .sort((a, b) => a[0] - b[0])
       .map((row) => row[1])


### PR DESCRIPTION
This commit fixes an error during runner logs download when the number of streams in logs was lower than 2 (e.g. when stderr was empty), and fixes undesired logs (i.e. not from main container) in the downloaded file when the order of streams in the API response was not the order expected by the webapp.