### PR TITLE
feat: add optional filters for datasources in workspace configuration

### DIFF
--- a/src/config/overrides/Workspaces.js
+++ b/src/config/overrides/Workspaces.js
@@ -122,6 +122,8 @@ export const WORKSPACES = [
           documentationUrl: 'https://portal.cosmotech.com/resources/platform-resources/platform-help',
         },
         datasetManager: {
+          datasourceFilter: undefined, // Filter example: ['etl_with_azure_storage', 'etl_with_local_file']
+          subdatasourceFilter: undefined, // Filter example: ['etl_sub_dataset_by_filter']
           graphIndicators: [
             { id: 'bars_count', name: { en: 'Bars', fr: 'Bars' }, queryId: 'bars' },
             { id: 'customers_count', name: { en: 'Customers', fr: 'Clients' }, queryId: 'customers' },

--- a/src/services/config/WorkspaceSchema.js
+++ b/src/services/config/WorkspaceSchema.js
@@ -109,6 +109,8 @@ const basicWebAppOptions = z.object({
     .nullable(),
   datasetManager: z
     .object({
+      datasourceFilter: z.array(z.string().optional()).optional().nullable(),
+      subdatasourceFilter: z.array(z.string().optional()).optional().nullable(),
       graphIndicators: z.array(TWINGRAPH_INDICATOR).optional().nullable(),
       categories: z
         .array(

--- a/src/views/DatasetManager/components/CreateDatasetButton/CreateDatasetButtonHook.js
+++ b/src/views/DatasetManager/components/CreateDatasetButton/CreateDatasetButtonHook.js
@@ -5,12 +5,14 @@ import { DATASET_SOURCE_TYPE, DATASET_SOURCES } from '../../../../services/confi
 import { useCreateDataset } from '../../../../state/hooks/DatasetHooks';
 import { useCreateRunner } from '../../../../state/hooks/RunnerHooks';
 import { useDataSourceRunTemplates, useSolutionData } from '../../../../state/hooks/SolutionHooks';
+import { useWorkspaceData } from '../../../../state/hooks/WorkspaceHooks';
 import { ArrayDictUtils, SolutionsUtils } from '../../../../utils';
 
 export const useDatasetCreationParameters = () => {
   const createDataset = useCreateDataset();
   const createRunner = useCreateRunner();
   const solutionData = useSolutionData();
+  const workspace = useWorkspaceData();
   const customDataSourceRunTemplates = useDataSourceRunTemplates();
 
   const dataSourceRunTemplates = useMemo(() => {
@@ -21,12 +23,20 @@ export const useDatasetCreationParameters = () => {
       parameters: parameters.filter((parameter) => runTemplatesParameters[dataSource.id].includes(parameter.id)),
     }));
 
+    const datasourceFilter = workspace?.webApp?.options?.datasetManager?.datasourceFilter;
     const runTemplates = {};
-    [...DATASET_SOURCES, ...dataSourcesWithParameters].forEach(
-      (runTemplate) => (runTemplates[runTemplate.id] = runTemplate)
-    );
+    [...DATASET_SOURCES, ...dataSourcesWithParameters].forEach((runTemplate) => {
+      if (datasourceFilter == null || datasourceFilter.indexOf(runTemplate.id) !== -1)
+        runTemplates[runTemplate.id] = runTemplate;
+    });
+
     return runTemplates;
-  }, [customDataSourceRunTemplates, solutionData.parameters, solutionData.runTemplatesParametersIdsDict]);
+  }, [
+    customDataSourceRunTemplates,
+    solutionData.parameters,
+    solutionData.runTemplatesParametersIdsDict,
+    workspace?.webApp?.options?.datasetManager?.datasourceFilter,
+  ]);
 
   const createDatasetOrRunner = useCallback(
     (values) => {


### PR DESCRIPTION
In workspace description, the following keys can be used to filter, in the current workspace, the list of run templates (resp. for dataset and subdataset creation) to show in the dataset manager:
- [workspace].webApp.options.datasetManager.datasourceFilter
- [workspace].webApp.options.datasetManager.subdatasourceFilter
