### PR TITLE
fix: [PROD-13974] fix not updated parentId when a runner is deleted

### DIFF
--- a/src/state/reducers/runner/RunnerReducer.js
+++ b/src/state/reducers/runner/RunnerReducer.js
@@ -102,6 +102,7 @@ export const runnerReducer = createReducer(runnersInitialState, (builder) => {
     })
     .addCase(RUNNER_ACTIONS_KEY.DELETE_RUNNER, (state, action) => {
       const index = state.list?.data.findIndex((runner) => runner.id === action.runnerId);
+      RunnersUtils.updateParentIdOnDelete(state.list?.data, action.runnerId);
       state.list?.data.splice(index, 1);
       if (state.current.data?.id === action.runnerId) state.current.data = null;
     })

--- a/src/utils/RunnersUtils.js
+++ b/src/utils/RunnersUtils.js
@@ -32,7 +32,17 @@ const patchRunnerWithCurrentUserPermissions = (runner, userEmail, userId, permis
   };
 };
 
+const updateParentIdOnDelete = (runners, deletedRunnerId) => {
+  const parentId = runners.find((runner) => runner.id === deletedRunnerId)?.parentId;
+  runners.forEach((runner) => {
+    if (runner.parentId !== deletedRunnerId) return;
+
+    runner.parentId = parentId ?? null;
+  });
+};
+
 export const RunnersUtils = {
   patchRunnerWithCurrentUserPermissions,
   patchRunnerParameterValues,
+  updateParentIdOnDelete,
 };

--- a/src/utils/__test__/RunnersUtils.spec.js
+++ b/src/utils/__test__/RunnersUtils.spec.js
@@ -61,3 +61,100 @@ describe('patchScenarioParameterValues', () => {
     spyConsoleWarn.mockClear();
   });
 });
+
+describe('update parentId on delete', () => {
+  test('can update parentId if parent has been deleted', () => {
+    const runners = [
+      { id: 'r-1', parentId: null },
+      { id: 'r-2', parentId: 'r-1' },
+      { id: 'r-3', parentId: 'r-2' },
+    ];
+    const runnersAfterUpdate = [
+      { id: 'r-1', parentId: null },
+      { id: 'r-2', parentId: 'r-1' },
+      { id: 'r-3', parentId: 'r-1' },
+    ];
+    RunnersUtils.updateParentIdOnDelete(runners, 'r-2');
+    expect(runners).toStrictEqual(runnersAfterUpdate);
+  });
+  test('can assign parentId to null if no higher parents', () => {
+    const runners = [
+      { id: 'r-1', parentId: null },
+      { id: 'r-2', parentId: 'r-1' },
+      { id: 'r-3', parentId: 'r-1' },
+    ];
+    const runnersAfterUpdate = [
+      { id: 'r-1', parentId: null },
+      { id: 'r-2', parentId: null },
+      { id: 'r-3', parentId: null },
+    ];
+    RunnersUtils.updateParentIdOnDelete(runners, 'r-1');
+    expect(runners).toStrictEqual(runnersAfterUpdate);
+  });
+  test("doesn't update array if no children scenarios", () => {
+    const runners = [
+      { id: 'r-1', parentId: null },
+      { id: 'r-2', parentId: 'r-1' },
+      { id: 'r-3', parentId: null },
+    ];
+    const runnersAfterUpdate = [
+      { id: 'r-1', parentId: null },
+      { id: 'r-2', parentId: 'r-1' },
+      { id: 'r-3', parentId: null },
+    ];
+    RunnersUtils.updateParentIdOnDelete(runners, 'r-3');
+    expect(runners).toStrictEqual(runnersAfterUpdate);
+  });
+  test('can update parentId in nested tree', () => {
+    const runners = [
+      { id: 'r-1', parentId: null },
+      { id: 'r-2', parentId: 'r-1' },
+      { id: 'r-3', parentId: 'r-2' },
+      { id: 'r-4', parentId: 'r-3' },
+      { id: 'r-5', parentId: 'r-4' },
+    ];
+    const runnersAfterUpdate = [
+      { id: 'r-1', parentId: null },
+      { id: 'r-2', parentId: 'r-1' },
+      { id: 'r-3', parentId: 'r-2' },
+      { id: 'r-4', parentId: 'r-2' },
+      { id: 'r-5', parentId: 'r-4' },
+    ];
+    RunnersUtils.updateParentIdOnDelete(runners, 'r-3');
+    expect(runners).toStrictEqual(runnersAfterUpdate);
+  });
+  test('can update parentId in large tree', () => {
+    const runners = [
+      { id: 'r-1', parentId: null },
+      { id: 'r-2', parentId: 'r-1' },
+      { id: 'r-3', parentId: 'r-2' },
+      { id: 'r-4', parentId: 'r-2' },
+      { id: 'r-5', parentId: 'r-2' },
+      { id: 'r-6', parentId: 'r-1' },
+    ];
+    const runnersAfterUpdate = [
+      { id: 'r-1', parentId: null },
+      { id: 'r-2', parentId: 'r-1' },
+      { id: 'r-3', parentId: 'r-1' },
+      { id: 'r-4', parentId: 'r-1' },
+      { id: 'r-5', parentId: 'r-1' },
+      { id: 'r-6', parentId: 'r-1' },
+    ];
+    RunnersUtils.updateParentIdOnDelete(runners, 'r-2');
+    expect(runners).toStrictEqual(runnersAfterUpdate);
+  });
+  test("can update parentId if target scenario isn't in the list", () => {
+    const runners = [
+      { id: 'r-1', parentId: null },
+      { id: 'r-2', parentId: 'r-4' },
+      { id: 'r-3', parentId: 'r-2' },
+    ];
+    const runnersAfterUpdate = [
+      { id: 'r-1', parentId: null },
+      { id: 'r-2', parentId: 'r-4' },
+      { id: 'r-3', parentId: 'r-4' },
+    ];
+    RunnersUtils.updateParentIdOnDelete(runners, 'r-2');
+    expect(runners).toStrictEqual(runnersAfterUpdate);
+  });
+});


### PR DESCRIPTION
Before creating a PR, please check that:
- [ ] Code is clean
- [ ] Tests are still working (cypress tests and `yarn test`)
- [ ] Changes don't cause new errors or warnings in browser console
- [ ] Documentation is up-to-date
- [ ] Breaking changes are clearly identified with [conventional commits](https://kapeli.com/cheat_sheets/Conventional_Commits.docset/Contents/Resources/Documents/index)
