### PR TITLE
feat: make graph item attributes order configurable in Instance view

### DIFF
--- a/doc/instanceVisualization.md
+++ b/doc/instanceVisualization.md
@@ -89,6 +89,10 @@ For all types of graph elements, the expected format of these object values is i
   modifiers will be applied via a selector (c.f. the [cytoscape documentation](https://js.cytoscape.org/#style) for the
   list of possible customization options)
 
+In addition to the cytoscape modifiers, you can define an array in an `attributesOrder` property, for each entity type,
+to force the order in which the entity attributes are displayed when an entity of this type is selected. The attributes
+that are not present in this list will be displayed below all other attributes.
+
 The example below illustrates how to use `Bar` and `Customer` entities as nodes, `arc_Satisfaction` as arcs and
 `Bar_vertex` as parent relations between bars and customers:
 
@@ -100,6 +104,7 @@ dataContent:
     arc_Satisfaction:
       style: { 'line-color': '#999999' }
       selectable: false
+      attributesOrder: ['id', 'name']
   nodes:
     Bar:
       style:
@@ -114,6 +119,7 @@ dataContent:
       style:
         background-color: '#005A31'
         shape: 'ellipse'
+      attributesOrder: ['id', 'Satisfaction', 'SurroundingSatisfaction']
 ```
 
 ---

--- a/src/config/overrides/Workspaces.js
+++ b/src/config/overrides/Workspaces.js
@@ -93,9 +93,7 @@ export const WORKSPACES = [
         },
         instanceView: {
           dataSource: {
-            type: 'azure_function',
-            functionUrl: 'https://scenario-download-brewery-dev.azurewebsites.net/api/ScenarioDownload',
-            functionKey: 'o5Xlur_7s5c00KQKnl0QveXVEFC9DXeBiOkwQEdZGx9xAzFuLsPB5A==',
+            type: 'twingraph_dataset',
           },
           dataContent: {
             compounds: { Bar_vertex: {} },

--- a/src/config/overrides/Workspaces.js
+++ b/src/config/overrides/Workspaces.js
@@ -111,8 +111,12 @@ export const WORKSPACES = [
                 pannable: true,
                 selectable: true,
                 grabbable: false,
+                attributesOrder: ['id', 'Stock', 'RestockQty', 'NbWaiters'],
               },
-              Customer: { style: { 'background-color': '#005A31', shape: 'ellipse' } },
+              Customer: {
+                style: { 'background-color': '#005A31', shape: 'ellipse' },
+                attributesOrder: ['id', 'Thirsty', 'Satisfaction', 'SurroundingSatisfaction'],
+              },
             },
           },
         },

--- a/src/utils/InstanceUtils.js
+++ b/src/utils/InstanceUtils.js
@@ -1,0 +1,25 @@
+// Copyright (c) Cosmo Tech.
+// Licensed under the MIT license.
+
+const mergeArrays = (array1, array2) => Array.from(new Set(array1.concat(array2)));
+
+const _mergeGraphItemAttributesConfigurationForElementType = (instanceViewConfig, twingraphItemsKeys, elementType) => {
+  const keys = twingraphItemsKeys?.[elementType] ?? {};
+  const config = instanceViewConfig?.dataContent?.[elementType] ?? {};
+  Object.entries(config).forEach(([entityType, entityOptions]) => {
+    if (entityOptions.attributesOrder != null && Array.isArray(entityOptions.attributesOrder))
+      keys[entityType] = mergeArrays(entityOptions.attributesOrder, keys[entityType]);
+  });
+  return keys;
+};
+
+const mergeGraphItemAttributesConfiguration = (instanceViewConfig, twingraphItemsKeys) => {
+  return {
+    nodes: _mergeGraphItemAttributesConfigurationForElementType(instanceViewConfig, twingraphItemsKeys, 'nodes'),
+    edges: _mergeGraphItemAttributesConfigurationForElementType(instanceViewConfig, twingraphItemsKeys, 'edges'),
+  };
+};
+
+export const InstanceUtils = {
+  mergeGraphItemAttributesConfiguration,
+};

--- a/src/utils/__test__/InstanceUtils.spec.js
+++ b/src/utils/__test__/InstanceUtils.spec.js
@@ -1,0 +1,84 @@
+// Copyright (c) Cosmo Tech.
+// Licensed under the MIT license.
+import { InstanceUtils } from '../InstanceUtils';
+
+const VALID_VIEW_CONFIG = {
+  dataContent: {
+    compounds: { Bar_vertex: {} }, // Field 'compounds' is not relevant for the function and will be ignored
+    edges: {
+      arc_Satisfaction: {
+        foo: 'bar', // Field 'foo' is not relevant for the function and will be ignored
+        attributesOrder: ['id', 'unknown_attribute'], // Extra attribute that won't be in twingraph keys
+      },
+    },
+    nodes: { Customer: { attributesOrder: ['A1', 'B1', 'C1', 'A2'] } },
+  },
+};
+const VALID_TWINGRAPH_KEYS = {
+  nodes: {
+    Bar: ['id', 'NbWaiters', 'RestockQty', 'Stock'], // Entity type not present in view config
+    Customer: ['id', 'Thirsty', 'B1', 'A2', 'C1', 'A1'], // Unordered, with some keys not defined in view config
+  },
+  edges: { arc_Satisfaction: ['id'] },
+};
+
+const EXPECTED_RESULT_FROM_TWINGRAPH_KEYS_ONLY = VALID_TWINGRAPH_KEYS;
+const EXPECTED_RESULT_FROM_CONFIG_ONLY = {
+  nodes: { Customer: ['A1', 'B1', 'C1', 'A2'] },
+  edges: { arc_Satisfaction: ['id', 'unknown_attribute'] },
+};
+
+const EXPECTED_RESULT_AFTER_MERGE = {
+  nodes: { Bar: ['id', 'NbWaiters', 'RestockQty', 'Stock'], Customer: ['A1', 'B1', 'C1', 'A2', 'id', 'Thirsty'] },
+  edges: { arc_Satisfaction: ['id', 'unknown_attribute'] }, // Extra attribute that won't be in twingraph keys
+};
+
+describe('mergeGraphItemAttributesConfiguration', () => {
+  test('returns default data with invalid instance view config', () => {
+    const result = InstanceUtils.mergeGraphItemAttributesConfiguration(null, VALID_TWINGRAPH_KEYS);
+    expect(result).toEqual(EXPECTED_RESULT_FROM_TWINGRAPH_KEYS_ONLY);
+  });
+
+  test('returns default data with invalid twingraph items keys', () => {
+    const result = InstanceUtils.mergeGraphItemAttributesConfiguration(VALID_VIEW_CONFIG, null);
+    expect(result).toEqual(EXPECTED_RESULT_FROM_CONFIG_ONLY);
+  });
+
+  test('merges node and edge configurations correctly', () => {
+    const result = InstanceUtils.mergeGraphItemAttributesConfiguration(VALID_VIEW_CONFIG, VALID_TWINGRAPH_KEYS);
+    expect(result).toEqual(EXPECTED_RESULT_AFTER_MERGE);
+  });
+
+  test('handles empty attributesOrder arrays', () => {
+    const config = {
+      dataContent: {
+        nodes: { Customer: { attributesOrder: [] } },
+        edges: { arc_Satisfaction: { attributesOrder: [] } },
+      },
+    };
+    const result = InstanceUtils.mergeGraphItemAttributesConfiguration(config, VALID_TWINGRAPH_KEYS);
+    expect(result).toEqual(EXPECTED_RESULT_FROM_TWINGRAPH_KEYS_ONLY);
+  });
+
+  test('ignores configurations without attributesOrder', () => {
+    const config = {
+      dataContent: {
+        nodes: { Customer: { foo: 'bar' } },
+        edges: { arc_Satisfaction: { baz: 'qux' } },
+      },
+    };
+    const result = InstanceUtils.mergeGraphItemAttributesConfiguration(config, VALID_TWINGRAPH_KEYS);
+    expect(result).toEqual(EXPECTED_RESULT_FROM_TWINGRAPH_KEYS_ONLY);
+  });
+
+  test('handles non-array attributesOrder values', () => {
+    const config = {
+      dataContent: {
+        nodes: { Customer: { attributesOrder: 'invalid' } },
+        edges: { arc_Satisfaction: { attributesOrder: 123 } },
+      },
+    };
+    const result = InstanceUtils.mergeGraphItemAttributesConfiguration(config, VALID_TWINGRAPH_KEYS);
+    expect(result).toEqual(EXPECTED_RESULT_FROM_TWINGRAPH_KEYS_ONLY);
+  });
+});

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -5,6 +5,7 @@ export { ApiUtils } from './ApiUtils';
 export { ArrayDictUtils } from './ArrayDictUtils';
 export { ConfigUtils } from './ConfigUtils';
 export { DatasetsUtils } from './DatasetsUtils';
+export { InstanceUtils } from './InstanceUtils';
 export { OrganizationsUtils } from './OrganizationsUtils';
 export { PowerBIUtils } from './PowerBIUtils';
 export { RouterUtils } from './RouterUtils';


### PR DESCRIPTION
In the workspace configuration, in the 'instanceView' object, one can now define an optional property "attributesOrder" to specify the desired order in which the graph items attributes must be displayed.

Configuration example:
```
  instanceView: {
    dataSource: { type: 'twingraph_dataset' },
    dataContent: {
      edges: { arc_Satisfaction: { style: {}, selectable: true, attributesOrder: ['id', 'name'] } },
      nodes: {
        Bar: { pannable: true, selectable: true, grabbable: false },
        Customer: {
          style: { 'background-color': '#005A31', shape: 'ellipse' },
          attributesOrder: [ 'id', 'A1', 'B1', 'C1', 'A2', 'B2', 'A3', 'A4', ],
        },
      },
    },
  },
```

If some attributes are missing in the list, they will be displayed after all the other attributes.
