### PR TITLE
fix: fix "stop run" button that was sometimes sending the id of the previous run

### DIFF
--- a/src/components/ScenarioParameters/components/ScenarioActions/ScenarioActions.spec.js
+++ b/src/components/ScenarioParameters/components/ScenarioActions/ScenarioActions.spec.js
@@ -7,7 +7,7 @@ import { useFormState } from 'react-hook-form';
 import { ButtonTesting, TypographyTesting } from '../../../../../tests/MuiComponentsTesting';
 import { customRender, getByDataCy } from '../../../../../tests/utils';
 import { SCENARIO_RUN_STATE } from '../../../../services/config/ApiConstants';
-import { useCurrentScenarioState } from '../../../../state/hooks/ScenarioHooks';
+import { useCurrentScenarioState, useCurrentScenarioLastRunId } from '../../../../state/hooks/ScenarioHooks';
 import { ScenarioActions } from './';
 
 jest.mock('react-hook-form', () => ({
@@ -39,6 +39,7 @@ jest.mock('../../../../state/hooks/ScenarioHooks', () => ({
   useSaveAndLaunchScenario: () => mockUseSaveAndLaunchScenario,
   useSaveScenario: () => mockUseSaveScenario,
   useCurrentScenarioState: jest.fn(),
+  useCurrentScenarioLastRunId: jest.fn(),
 }));
 
 jest.mock('../../../../state/hooks/ScenarioRunHooks', () => ({
@@ -132,6 +133,7 @@ describe('Test scenario buttons when scenario is not running', () => {
 describe('Test scenario buttons when scenario is running', () => {
   beforeAll(() => {
     useCurrentScenarioState.mockReturnValue(SCENARIO_RUN_STATE.RUNNING);
+    useCurrentScenarioLastRunId.mockReturnValue('sr-0123456');
     useFormState.mockReturnValue({ isDirty: false });
     customRender(<ScenarioActions />);
   });

--- a/src/components/ScenarioParameters/components/ScenarioActions/components/StopRunButton/StopRunButton.js
+++ b/src/components/ScenarioParameters/components/ScenarioActions/components/StopRunButton/StopRunButton.js
@@ -70,6 +70,7 @@ export const StopRunButton = () => {
       <Grid item>
         <Button
           data-cy="stop-scenario-run-button"
+          disabled={currentScenarioLastRunId == null}
           color="error"
           variant="contained"
           startIcon={<CancelIcon />}

--- a/src/state/sagas/scenario/LaunchScenario/LaunchScenario.js
+++ b/src/state/sagas/scenario/LaunchScenario/LaunchScenario.js
@@ -27,7 +27,7 @@ export function* launchScenario(action) {
 
     yield put({
       type: SCENARIO_ACTIONS_KEY.SET_CURRENT_SCENARIO,
-      scenario: { state: SCENARIO_RUN_STATE.RUNNING },
+      scenario: { state: SCENARIO_RUN_STATE.RUNNING, lastRun: undefined },
     });
 
     // Launch scenario if parameters update succeeded


### PR DESCRIPTION
- "Abort" button is now disabled when run id of the current scenario is nullish
- when starting a new run, the redux saga locally erases the scenario run data to force the scenario run to be nullish