### PR TITLE
fix: [PROD-13341] run templates aren't translated if runTemplateFilter is null

### DIFF
--- a/src/components/CreateScenarioButton/CreateScenarioButton.spec.js
+++ b/src/components/CreateScenarioButton/CreateScenarioButton.spec.js
@@ -35,6 +35,13 @@ const getStateWithWorkspaceRole = (role) => {
   return state;
 };
 
+const translateTemplatesInTest = (templates) => {
+  return templates.map((rt) => ({
+    ...rt,
+    name: `solution.runTemplate.${rt.id}.name`,
+  }));
+};
+
 const mockOnScenarioCreated = jest.fn();
 const DEFAULT_PROPS = {
   disabled: false,
@@ -179,7 +186,10 @@ describe('CreateScenarioButton', () => {
 
     test('when filter is missing runTemplates are not filtered', () => {
       setUpWithRunTemplateFilter(undefined);
-      expect(mockCreateScenarioUIProps.runTemplates).toEqual(DEFAULT_REDUX_STATE.solution.current.data.runTemplates);
+      const expectedTranslatedTemplates = translateTemplatesInTest(
+        DEFAULT_REDUX_STATE.solution.current.data.runTemplates
+      );
+      expect(mockCreateScenarioUIProps.runTemplates).toEqual(expectedTranslatedTemplates);
     });
 
     test('when filter is empty runTemplates are all filtered', () => {

--- a/src/components/CreateScenarioButton/CreateScenarioButtonHook.js
+++ b/src/components/CreateScenarioButton/CreateScenarioButtonHook.js
@@ -44,17 +44,22 @@ export const useCreateScenarioButton = ({ disabled, onScenarioCreated }) => {
 
   const filteredAndTranslatedRunTemplates = useMemo(() => {
     const runTemplateFilter = workspaceData?.solution?.runTemplateFilter;
-    if (!runTemplateFilter) return runTemplates;
+
+    const translateTemplates = (templates) => {
+      const cloned = clone(templates) ?? [];
+      cloned.forEach(
+        (runTemplate) =>
+          (runTemplate.name = t(TranslationUtils.getRunTemplateTranslationKey(runTemplate.id), runTemplate.name))
+      );
+      return cloned;
+    };
+
+    if (!runTemplateFilter) return translateTemplates(runTemplates);
+
     if (!runTemplateFilter.length) return [];
 
-    const filteredRunTemplates = runTemplates.filter((rt) => runTemplateFilter.includes(rt.id));
-    const translatedRunTemplates = clone(filteredRunTemplates) ?? [];
-    translatedRunTemplates.forEach(
-      (runTemplate) =>
-        (runTemplate.name = t(TranslationUtils.getRunTemplateTranslationKey(runTemplate.id), runTemplate.name))
-    );
-
-    return translatedRunTemplates;
+    const filtered = runTemplates.filter((rt) => runTemplateFilter.includes(rt.id));
+    return translateTemplates(filtered);
   }, [runTemplates, workspaceData?.solution?.runTemplateFilter, t, clone]);
 
   const createScenarioDialogLabels = getCreateScenarioDialogLabels(t, disabled);

--- a/src/views/SignIn/SignIn.js
+++ b/src/views/SignIn/SignIn.js
@@ -66,6 +66,7 @@ const SignIn = ({ logInAction, auth }) => {
                 {accessDeniedError}
                 <Grid>
                   <SignInButton
+                    autoFocus
                     logo={microsoftLogo}
                     id={'microsoft'}
                     label={t('genericcomponent.button.login.msal.title', 'Sign in with Microsoft')}


### PR DESCRIPTION
Before creating a PR, please check that:
- [ ] Code is clean
- [ ] Tests are still working (cypress tests and `yarn test`)
- [ ] Changes don't cause new errors or warnings in browser console
- [ ] Documentation is up-to-date
- [ ] Breaking changes are clearly identified with [conventional commits](https://kapeli.com/cheat_sheets/Conventional_Commits.docset/Contents/Resources/Documents/index)
