### PR TITLE
fix: [PROD-14626] search bar input value is now really null when clea…

### DIFF
--- a/src/views/Simulation/components/TopBar/SearchBar.js
+++ b/src/views/Simulation/components/TopBar/SearchBar.js
@@ -41,7 +41,7 @@ export const SearchBar = () => {
 
   const selectElement = (element) => {
     const elementId = element?.data?.id ?? element?.id;
-    setSelectedElementId(elementId);
+    setSelectedElementId(elementId ?? null);
     if (elementId != null) centerToPosition(elementId);
   };
 


### PR DESCRIPTION
…r is done

Before creating a PR, please check that:
- [ ] Code is clean
- [ ] Tests are still working (cypress tests and `yarn test`)
- [ ] Changes don't cause new errors or warnings in browser console
- [ ] Documentation is up-to-date
- [ ] Breaking changes are clearly identified with [conventional commits](https://kapeli.com/cheat_sheets/Conventional_Commits.docset/Contents/Resources/Documents/index)
