### PR TITLE
fix: [PROD-14663] re-center the scene when we resize window

### DIFF
--- a/src/views/Simulation/components/Scene/Scene.js
+++ b/src/views/Simulation/components/Scene/Scene.js
@@ -40,16 +40,7 @@ const Scene = () => {
 
     const setup = async () => {
       resetGraphLayout(sceneCanvasRef.current.clientWidth, sceneCanvasRef.current.clientHeight);
-      await initApp(
-        sceneAppRef,
-        sceneCanvasRef,
-        sceneContainerRef,
-        graphRef,
-        resetGraphLayout,
-        theme,
-        setSelectedElementId,
-        settings
-      );
+      await initApp(sceneAppRef, sceneCanvasRef, sceneContainerRef, graphRef, theme, setSelectedElementId, settings);
 
       await initMinimap(minimapAppRef, minimapContainerRef, minimapCanvasRef, sceneContainerRef, sceneCanvasRef, theme);
     };

--- a/src/views/Simulation/utils/pixiUtils.js
+++ b/src/views/Simulation/utils/pixiUtils.js
@@ -430,7 +430,6 @@ export const initApp = async (
   sceneCanvasRef,
   sceneContainerRef,
   graphRef,
-  resetGraphLayout,
   theme,
   setSelectedElementId,
   settings
@@ -461,6 +460,9 @@ export const initApp = async (
   const handleResize = () => {
     if (!canvas || !app?.renderer) return;
     app.renderer.resize(canvas.clientWidth, canvas.clientHeight);
+    if (sceneContainerRef.current) {
+      sceneContainerRef.current.setOrigin();
+    }
   };
 
   window.addEventListener('resize', handleResize);


### PR DESCRIPTION
Before creating a PR, please check that:
- [ ] Code is clean
- [ ] Tests are still working (cypress tests and `yarn test`)
- [ ] Changes don't cause new errors or warnings in browser console
- [ ] Documentation is up-to-date
- [ ] Breaking changes are clearly identified with [conventional commits](https://kapeli.com/cheat_sheets/Conventional_Commits.docset/Contents/Resources/Documents/index)
