### PR TITLE
fix: [PROD-14706] keep node coordinates & fix attribute labels in inspector drawer

### DIFF
--- a/src/views/Simulation/components/InspectorDrawer/components/ElementDetails.js
+++ b/src/views/Simulation/components/InspectorDrawer/components/ElementDetails.js
@@ -26,6 +26,14 @@ const DETAILS_METADATA = {
 
   isContractor: { label: 'Is contractor' },
   investmentCost: { label: 'Investment cost' },
+
+  partId: { label: 'Part id' },
+  MinimalStock: { label: 'Minimal stock' },
+  MaximalStock: { label: 'Maximal stock' },
+  BacklogWeight: { label: 'Backlog weight' },
+  MaximizationWeight: { label: 'Maximization weight' },
+  latitude: { label: 'Latitude' },
+  longitude: { label: 'Longitude' },
 };
 
 export const ElementDetails = ({ inspectedElement }) => {

--- a/src/views/Simulation/utils/graphUtils.js
+++ b/src/views/Simulation/utils/graphUtils.js
@@ -210,7 +210,7 @@ export const getGraphFromInstance = (scenario, settings) => {
     return {
       id: node.id,
       type,
-      data: forgeElementData(node, ['id', 'latitude', 'longitude']),
+      data: forgeElementData(node, ['id']),
     };
   };
 


### PR DESCRIPTION
- keep latitude & longitude data that were already in the _graph.json_ input files (they were removed when loading the files)
- fixed attribute labels in the inspector panel